### PR TITLE
Update to reticulate

### DIFF
--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -1,8 +1,10 @@
 # now call autoGenerateRdFiles
+library("synapser")
+library("reticulate")
+library("rjson")
 args <- commandArgs(TRUE)
 srcRootDir <- args[1]
-library("synapser")
-library("rjson")
+
 
 toOmit <- c("with_progress_bar", "notifyMe")
 .selectSynapseUtilsFunctionInfo <- function(x) {
@@ -12,8 +14,15 @@ toOmit <- c("with_progress_bar", "notifyMe")
   x
 }
 
+# 'source' some functions shared with the synapser package
+# to get omitFunctions and omitClasses
+source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
+
+reticulate::py_run_string("import sys")
+reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(srcRootDir, "inst", "python")))
+
 # generate the Python documentation
-PythonEmbedInR::generateRdFiles(srcRootDir,
+generateRdFiles(srcRootDir,
                 pyPkg = "synapseutils",
                 container = "synapseutils",
                 functionFilter = .selectSynapseUtilsFunctionInfo)


### PR DESCRIPTION
Fixed the error when installing the Synapseutils: 
```
Error in value[[3L]](cond) : 
  Error generating doc for changeFileMetaData: Failed to replace all placeholders in changeFileMetaData.Rd
Calls: generateRdFiles ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
Execution halted
ERROR: configuration failed for package ‘synapserutils’
* removing ‘/Library/Frameworks/R.framework/Versions/4.2/Resources/library/synapserutils’
```

Below is the success message:
```
> remotes::install_github(repo="https://github.com/danlu1/synapserutils.git",ref="update-to-reticulate")
Downloading GitHub repo danlu1/synapserutils@update-to-reticulate
Running `R CMD build`...
* checking for file ‘/private/var/folders/5s/4t3hsmg573b8h_jqh1hjj91m0000gn/T/Rtmp5Vx7pR/remotes504661e1f6cf/danlu1-synapserutils-e62c52d/DESCRIPTION’ ... OK
* preparing ‘synapserutils’:
* checking DESCRIPTION meta-information ... OK
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building ‘synapserutils_0.1.6.tar.gz’
* installing *source* package ‘synapserutils’ ...
** using staged installation

TERMS OF USE NOTICE:
  When using Synapse, remember that the terms and conditions of use require that you:
  1) Attribute data contributors when discussing these data or results from these data.
  2) Not discriminate, identify, or recontact individuals or groups represented by the data.
  3) Use and contribute only data de-identified to HIPAA standards.
  4) Redistribute data only under these same terms of use.

** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (synapserutils)

```